### PR TITLE
PLAT-99350: Re-order sampler resolver prioritization for local node_modules first

### DIFF
--- a/configs/webpack.js
+++ b/configs/webpack.js
@@ -58,7 +58,7 @@ module.exports = function(config, mode, dirname) {
 
 	// Modify stock Storybook config for Enact-tailored experience
 	config.devtool = shouldUseSourceMap && 'source-map';
-	config.resolve.modules = [path.resolve(app.context, 'node_modules'), 'node_modules'];
+	config.resolve.modules = ['node_modules', path.resolve(app.context, 'node_modules')];
 	config.devServer = {host: '0.0.0.0', port: 8080};
 	config.performance = {hints: false};
 


### PR DESCRIPTION
Allows the potential to modify root level agate and its dependencies independent of what the sampler itself is using.

Verified against agate sampler

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>