### PR TITLE
PLAT-100703: Fix ilib module resolution

### DIFF
--- a/configs/webpack.js
+++ b/configs/webpack.js
@@ -59,6 +59,11 @@ module.exports = function(config, mode, dirname) {
 	// Modify stock Storybook config for Enact-tailored experience
 	config.devtool = shouldUseSourceMap && 'source-map';
 	config.resolve.modules = ['node_modules', path.resolve(app.context, 'node_modules')];
+	config.resolve.alias = Object.assign({}, config.resolve.alias, {
+		// coerce everything to use the ilib installed with the sampler
+		// since it is set as a peer dependency by the enact modules
+		ilib: path.resolve(app.context, 'node_modules/ilib')
+	});
 	config.devServer = {host: '0.0.0.0', port: 8080};
 	config.performance = {hints: false};
 


### PR DESCRIPTION
Override the webpack resolution alias to coerce everything to use the ilib installed with the sampler since it is set as a peer dependency by the enact modules. With out this, we end up with multiple instances of ilib and only 1 is configured with the enact loader causing resource loading failures.