### PR TITLE
WRN-8250: Update PostCSS packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## unreleased
+
+* Removed `sanitize.css` dependency.
+* Updated CLI dependency of `postcss-normalize` to 10.0.1.
+
 ## 4.0.4 (September 28, 2021)
 
 * Added `sanitize.css` module for supporting `postcss-normalize`.

--- a/configs/webpack.js
+++ b/configs/webpack.js
@@ -24,10 +24,8 @@ module.exports = function (config, mode, dirname) {
 			{
 				loader: require.resolve('postcss-loader'),
 				options: {
-					ident: 'postcss',
-					sourceMap: shouldUseSourceMap,
-					plugins: () =>
-						[
+					postcssOptions: {
+						plugins: [
 							require('postcss-flexbugs-fixes'),
 							require('postcss-global-import'),
 							require('postcss-preset-env')({
@@ -41,6 +39,8 @@ module.exports = function (config, mode, dirname) {
 							require('postcss-normalize')(),
 							app.ri && require('postcss-resolution-independence')(app.ri)
 						].filter(Boolean)
+					},
+					sourceMap: shouldUseSourceMap,
 				}
 			}
 		];

--- a/package.json
+++ b/package.json
@@ -40,14 +40,14 @@
     "less": "^3.13.0",
     "less-loader": "^6.2.0",
     "mini-css-extract-plugin": "^0.11.3",
-    "postcss-flexbugs-fixes": "^4.2.1",
+    "postcss": "8.3.5",
+    "postcss-flexbugs-fixes": "^5.0.2",
     "postcss-global-import": "^1.0.6",
-    "postcss-loader": "^3.0.0",
-    "postcss-normalize": "^9.0.0",
+    "postcss-loader": "^4.2.0",
+    "postcss-normalize": "^10.0.1",
     "postcss-preset-env": "^6.7.0",
     "postcss-resolution-independence": "^1.0.0",
-    "react-dev-utils": "^11.0.1",
-    "sanitize.css": "^12.0.1"
+    "react-dev-utils": "^11.0.1"
   },
   "devDependencies": {
     "@storybook/react": "6.2.9",


### PR DESCRIPTION
### Issue Resolved / Feature Added
Some errors were found while `enact pack`

> Error: Cannot find module ‘sanitize.css/page.css’
Require stack:
/usr/local/lib/node_modules/@enact/cli/node_modules/postcss-normalize/dist/index.cjs.js
./node_modules/@enact/ui/Scroller/UiScroller.module.css
Error: Cannot find module ‘sanitize.css/page.css’
Require stack:
/usr/local/lib/node_modules/@enact/cli/node_modules/postcss-normalize/dist/index.cjs.js
./node_modules/@enact/ui/Scroller/Scroller.module.css
Error: Cannot find module ‘sanitize.css/page.css’
Require stack:
/usr/local/lib/node_modules/@enact/cli/node_modules/postcss-normalize/dist/index.cjs.js
./node_modules/@enact/sandstone/Dropdown/Dropdown.module.css

### Resolution
Update `postcss-normalize` to 10.0.1

### Additional Considerations
Update PostCSS packages because  `postcss-normalize` need `postcss` v8
(related to https://github.com/facebook/create-react-app/pull/10456)

### Links
WRN-8250

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)