### PR TITLE
WRN-9482: Fix showing unexpected string in sampler

### DIFF
--- a/addons/controls/select.js
+++ b/addons/controls/select.js
@@ -47,7 +47,11 @@ const select = (name, storyObj, items, config, selectedValue) => {
 	}
 
 	const defaultAppender = (key, label = key) => {
-		return (key || '(empty string)') + (config.defaultProps[name] === label ? defaultString : '');
+		if (typeof key === 'string' || key == null) {
+			return ' ';
+		}
+
+		return (key || ' ') + (config.defaultProps[name] === label ? defaultString : '');
 	};
 
 	if (items instanceof Array) {

--- a/addons/controls/select.js
+++ b/addons/controls/select.js
@@ -47,11 +47,7 @@ const select = (name, storyObj, items, config, selectedValue) => {
 	}
 
 	const defaultAppender = (key, label = key) => {
-		if (typeof key === 'undefined' || key == null) {
-			return ' ';
-		}
-
-		return (key || ' ') + (config.defaultProps[name] === label ? defaultString : '');
+		return (key || ' ') + (config.defaultProps[name] === label && key ? defaultString : '');
 	};
 
 	if (items instanceof Array) {

--- a/addons/controls/select.js
+++ b/addons/controls/select.js
@@ -47,7 +47,7 @@ const select = (name, storyObj, items, config, selectedValue) => {
 	}
 
 	const defaultAppender = (key, label = key) => {
-		return (key || ' ') + (config.defaultProps[name] === label && key ? defaultString : '');
+		return (key || '') + (config.defaultProps[name] === label && key ? defaultString : '');
 	};
 
 	if (items instanceof Array) {

--- a/addons/controls/select.js
+++ b/addons/controls/select.js
@@ -47,7 +47,7 @@ const select = (name, storyObj, items, config, selectedValue) => {
 	}
 
 	const defaultAppender = (key, label = key) => {
-		if (typeof key === 'string' || key == null) {
+		if (typeof key === 'undefined' || key == null) {
 			return ' ';
 		}
 

--- a/addons/controls/select.js
+++ b/addons/controls/select.js
@@ -62,7 +62,9 @@ const select = (name, storyObj, items, config, selectedValue) => {
 		}
 	}
 
-	storyObj.args[name] = defaultAppender(selectedValue != null ? selectedValue : config.defaultProps[name]);
+	const value = nullify(selectedValue != null ? selectedValue : config.defaultProps[name]);
+	storyObj.args[name] = Object.keys(labels).find(key => labels[key] === value);
+
 	storyObj.argTypes[name] = {
 		options: Object.keys(labels),
 		mapping: labels,


### PR DESCRIPTION
When the `select` knob is used, we were able to select `undefined` or `null` through knobs.
But with `controls`, we cannot set `undefined` or `null` by default so we added `(empty string)` for that case.
Unfortunately, this leads to show unexpected string in some sampler so we've replaced it with`''`.
Also, when we have a default prop, we need to pass the exact name(the key of labels) to args.

Enact-DCO-1.0-Signed-off-by: SJ RO (sj.ro@lge.com)