### PR TITLE
WRO-5043:Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
+dist: focal
 language: node_js
 node_js:
-    - "14"
+    - node 
 sudo: false
-cache:
-  directories:
-    - $(npm config get cache)
 install:
-    - npm config set prefer-offline true
+    - npm config set prefer-offline false
     - npm install
 
 script:


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Requires travis test on current node versions and since npm is cached by default in Travis CI, there is no need for code related to the npm cache.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Update .travis.yml so that it can be tested on current node versions (node(18)).
- ubuntu 20 is required for node 18 ( https://docs.travis-ci.com/user/reference/focal/)

Remove cache description and set the prefer-offline config value to false so that stale check on cached data are not bypassed.
- npm is cached by default on Travis CI from July 2019. (https://docs.travis-ci.com/user/caching/)
- https://docs.npmjs.com/cli/v8/using-npm/config#prefer-offline

### Comments
Enact-DCO-1.0-Signed-off-by: SJ RO (sj.ro@lge.com)