### PR TITLE
WRO-7575: Fix styles of some stories are not showing properly with webpack5

### DIFF
--- a/configs/webpack.js
+++ b/configs/webpack.js
@@ -98,8 +98,7 @@ module.exports = function (config, mode, dirname) {
 			test: /\.module\.css$/,
 			use: getStyleLoaders({
 				modules: {
-					getLocalIdent,
-					mode: 'local'
+					getLocalIdent
 				}
 			})
 		},
@@ -109,8 +108,7 @@ module.exports = function (config, mode, dirname) {
 			// modular CSS support.
 			use: getStyleLoaders({
 				modules: {
-					...(app.forceCSSModules ? {getLocalIdent} : {}),
-					mode: 'icss'
+					...(app.forceCSSModules ? {getLocalIdent} : {mode: 'icss'})
 				}
 			}),
 			// Don't consider CSS imports dead code even if the
@@ -123,8 +121,7 @@ module.exports = function (config, mode, dirname) {
 			test: /\.module\.less$/,
 			use: getLessStyleLoaders({
 				modules: {
-					getLocalIdent,
-					mode: 'local'
+					getLocalIdent
 				}
 			})
 		},
@@ -132,8 +129,7 @@ module.exports = function (config, mode, dirname) {
 			test: /\.less$/,
 			use: getLessStyleLoaders({
 				modules: {
-					...(app.forceCSSModules ? {getLocalIdent} : {}),
-					mode: 'icss'
+					...(app.forceCSSModules ? {getLocalIdent} : {mode: 'icss'})
 				}
 			}),
 			sideEffects: true
@@ -168,13 +164,28 @@ module.exports = function (config, mode, dirname) {
 		new ILibPlugin({publicPath}),
 		new WebOSMetaPlugin({path: path.join(dirname, 'webos-meta')})
 	);
+
 	if (!process.env.INLINE_STYLES) {
 		config.plugins.push(
 			new MiniCssExtractPlugin({
 				filename: '[name].css',
-				chunkFilename: 'chunk.[name].css'
+				chunkFilename: 'chunk.[name].css',
+				ignoreOrder: true
 			})
 		);
+
+		config.optimization = Object.assign({}, config.optimization, {
+			splitChunks: {
+				cacheGroups: {
+					styles: {
+						name: 'styles',
+						type: 'css/mini-extract',
+						chunks: 'all',
+						enforce: true
+					}
+				}
+			}
+		});
 	}
 
 	return config;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
After updating storybook 6.5 and webpack 5, we've found that ContextualPopup of ContextualMenuDecorator is opened with narrow width.
The root cause of this issue came from Storybook's on-demand story loading feature(https://storybook.js.org/docs/react/configure/overview#on-demand-story-loading).
To be specific, when Storybook loads stories on-demand(with `storyStoreV7` option), it links the CSS chunk built from the specific JS story file and the CSS chunks built from the previous story and the next story. In other words, when `ContexualPopupMenuDecorator` opened, it has the CSS chunk from `ContextualPopupMenuDecorator` story as well as `ContexualPopupDecorator` and `CheckboxItem` story's.
Both chunk.ContexualMenuDecorator.css and chunk.ContextualPopupDecorator.css have the same class definition redundantly.
This caused the issue.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
To resolve the issue, I made `mini-css-extract-plugin` to extract all CSS in a single file according to https://webpack.js.org/plugins/mini-css-extract-plugin/#extracting-all-css-in-a-single-file.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Also fixed css-loader `mode` option to work properly with `app.forceCSSModules`.

### Links
[//]: # (Related issues, references)
WRO-7575

### Comments
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)