### PR TITLE
WRO-13215: Fixed not loading stories without `storyStoreV7` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-* Fixed not loading stories without `storyStoreV7` option by adding `cjs` file to be excluded from `file-loader`.
+* Fixed not loading stories without `storyStoreV7` option by making `cjs` file not be treated as an asset or resource.
 * Replaced deprecated `register` with `manager` for addons.
 * Fixed `showName` warning by changing `title` property to `name` value in the controls addon.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+* Fixed not loading stories without `storyStoreV7` option by adding `cjs` file to be excluded from `file-loader`.
 * Replaced deprecated `register` with `manager` for addons.
 * Fixed `showName` warning by changing `title` property to `name` value in the controls addon.
 

--- a/configs/webpack.js
+++ b/configs/webpack.js
@@ -135,7 +135,7 @@ module.exports = function (config, mode, dirname) {
 			sideEffects: true
 		},
 		{
-			exclude: [/^$/, /\.(js|mjs|jsx|ts|tsx)$/, /\.html$/, /\.ejs$/, /\.json$/],
+			exclude: [/^$/, /\.(js|mjs|cjs|jsx|ts|tsx)$/, /\.html$/, /\.ejs$/, /\.json$/],
 			type: 'asset/resource'
 		}
 	);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Without `storyStoreV7` option, stories are not loading.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
When I inspected the sampler, it seems it cannot load generated-stories-entry.cjs file.
Storybook changed generated-stories-entry.js file to generated-stories-entry.cjs from 6.5.0-alpha.39.
Apparently some samplers with type: module and webpack5 builder had a "require is not defined" error. To resolve this, storybook had to rename generated-stories-entry.js file to .cjs file and this led to our sampler loads stories forever.
According to the comments of storybook issue #14877, it was reverted once for the same issue as ours from CRA5 users but CRA preset had been fixed.
Referring to that fix, we could fix our webpack config from storybook-utils like them and it worked as expected with .cjs file.

Detailed links are provided in the ticket.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
WRO-13215

### Comments
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)