### PR TITLE
WRO-13139: Add modules from @storybook/addon-docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+* Added `Primary, Stories, Title` to the `@storybook/addon-docs` export for customizing docs page.
 * Fixed not loading stories without `storyStoreV7` option by making `cjs` file not be treated as an asset or resource.
 * Replaced deprecated `register` with `manager` for addons.
 * Fixed `showName` warning by changing `title` property to `name` value in the controls addon.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-* Added `Primary, Stories, Title` to the `@storybook/addon-docs` export for customizing docs page.
+* Added `Primary, Stories, and Title` to the docs addon exports for customizing the docs page.
 * Fixed not loading stories without `storyStoreV7` option by making `cjs` file not be treated as an asset or resource.
 * Replaced deprecated `register` with `manager` for addons.
 * Fixed `showName` warning by changing `title` property to `name` value in the controls addon.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-* Added `Primary, Stories, and Title` to the docs addon exports for customizing the docs page.
+* Added `Primary`, `Stories`, and `Title` to the docs addon exports for customizing the docs page.
 * Fixed not loading stories without `storyStoreV7` option by making `cjs` file not be treated as an asset or resource.
 * Replaced deprecated `register` with `manager` for addons.
 * Fixed `showName` warning by changing `title` property to `name` value in the controls addon.

--- a/addons/docs/docs.js
+++ b/addons/docs/docs.js
@@ -1,1 +1,1 @@
-export {DocsPage, DocsContainer} from '@storybook/addon-docs';
+export {DocsPage, DocsContainer, Primary, Stories, Title} from '@storybook/addon-docs';


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Stanca Pop [stanca.pop@lgepartner.com](mailto:stanca.pop@lgepartner.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In storybook, if controls are changed from Docs tab, it doesn't update the component preview.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
As there was no optimum solution for this bug, we agreed to remove controls from the docs page. Therefore we needed to export {Primary, Stories, Title} from '@storybook/addon-docs' and use them to manually set the docs parameters.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-13139

### Comments
