### PR TITLE
WRP-6904: Remove eslint-related modules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,3 @@
-// This is a workaround for https://github.com/eslint/eslint/issues/3458
-require('@rushstack/eslint-patch/modern-module-resolution');
-
 module.exports = {
 	env: {
 		node: true

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,6 @@
+// This is a workaround for https://github.com/eslint/eslint/issues/3458
+require('@rushstack/eslint-patch/modern-module-resolution');
+
 module.exports = {
 	env: {
 		node: true

--- a/package.json
+++ b/package.json
@@ -47,23 +47,16 @@
     "react-dev-utils": "^12.0.1"
   },
   "devDependencies": {
+    "@rushstack/eslint-patch": "^1.3.2",
     "@storybook/react": "^6.5.16",
     "@storybook/source-loader": "^6.5.16",
     "babel-loader": "^9.1.2",
+    "eslint": "^8.37.0",
     "eslint-config-enact": "^4.1.4",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-prettier": "^4.2.1",
     "prettier": "^2.8.7",
     "webpack": "^5.77.0"
-  },
-  "peerDependencies": {
-    "@babel/eslint-plugin": "*",
-    "eslint": "*",
-    "eslint-plugin-enact": "*",
-    "eslint-plugin-jest": "*",
-    "eslint-plugin-jsx-a11y": "*",
-    "eslint-plugin-react": "*",
-    "eslint-plugin-react-hooks": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,12 +47,11 @@
     "react-dev-utils": "^12.0.1"
   },
   "devDependencies": {
-    "@rushstack/eslint-patch": "^1.3.2",
     "@storybook/react": "^6.5.16",
     "@storybook/source-loader": "^6.5.16",
     "babel-loader": "^9.1.2",
     "eslint": "^8.37.0",
-    "eslint-config-enact": "^4.1.4",
+    "eslint-config-enact": "github:enactjs/eslint-config-enact#feature/WRP-6904",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-prettier": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -47,21 +47,23 @@
     "react-dev-utils": "^12.0.1"
   },
   "devDependencies": {
-    "@babel/eslint-plugin": "^7.19.1",
     "@storybook/react": "^6.5.16",
     "@storybook/source-loader": "^6.5.16",
     "babel-loader": "^9.1.2",
-    "eslint": "^8.37.0",
     "eslint-config-enact": "^4.1.4",
     "eslint-config-prettier": "^8.8.0",
-    "eslint-plugin-enact": "^1.0.2",
     "eslint-plugin-import": "^2.27.5",
-    "eslint-plugin-jest": "^27.2.1",
-    "eslint-plugin-jsx-a11y": "^6.7.1",
     "eslint-plugin-prettier": "^4.2.1",
-    "eslint-plugin-react": "^7.32.2",
-    "eslint-plugin-react-hooks": "^4.6.0",
     "prettier": "^2.8.7",
     "webpack": "^5.77.0"
+  },
+  "peerDependencies": {
+    "@babel/eslint-plugin": "*",
+    "eslint": "*",
+    "eslint-plugin-enact": "*",
+    "eslint-plugin-jest": "*",
+    "eslint-plugin-jsx-a11y": "*",
+    "eslint-plugin-react": "*",
+    "eslint-plugin-react-hooks": "*"
   }
 }


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Previously, there were attempts to install each eslint-related module in one repo(ex: eslint-config-enact) so that each tooling (dev-utils, cli, storybook-utils, ui-test-utils) does not install additional eslint-related modules.
The installation of eslint-config-enact alone did not install the necessary eslint-related modules, so it had to be managed separately, and the reason was not known.
This patch is a workaround for a longstanding https://github.com/eslint/eslint/issues/3458 that would allow a shared ESLint config to bring along its own plugins, rather than imposing peer dependencies on every consumer of the config.
Doing so greatly reduces the copy+pasting and version management for all the other projects that use your standard lint rule set, but don't want to be bothered with the details.

References
- discussions: https://github.com/eslint/eslint/issues/3458
- workaround: https://www.npmjs.com/package/@rushstack/eslint-patch

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Remove eslint-related modules and apply https://github.com/enactjs/eslint-config-enact/pull/66

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
We can remove eslint-related modules after release https://github.com/enactjs/eslint-config-enact/pull/66

### Links
[//]: # (Related issues, references)
WRP-6904

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)