### PR TITLE
WRQ-200: Remove getCSSModuleLocalIdent and use cssModuleIdent only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## unreleased
+
+* Removed `getCSSModuleLocalIdent` to fix unexpected behaviors in css-loader.
+
 ## 5.1.1 (September 21, 2023)
 
 * Updated `postcss-preset-env` version to `^9.1.1`.

--- a/configs/webpack.js
+++ b/configs/webpack.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const NodePolyfillPlugin = require('node-polyfill-webpack-plugin');
-const getLocalIdent = require('react-dev-utils/getCSSModuleLocalIdent');
+const {cssModuleIdent: getLocalIdent} = require('@enact/dev-utils');
 const {DefinePlugin} = require('webpack');
 const {optionParser: app, GracefulFsPlugin, ILibPlugin, WebOSMetaPlugin} = require('@enact/dev-utils');
 

--- a/package.json
+++ b/package.json
@@ -43,8 +43,7 @@
     "postcss-loader": "^7.3.3",
     "postcss-normalize": "^10.0.1",
     "postcss-preset-env": "^9.1.4",
-    "postcss-resolution-independence": "^1.1.3",
-    "react-dev-utils": "^12.0.1"
+    "postcss-resolution-independence": "^1.1.3"
   },
   "devDependencies": {
     "@babel/eslint-plugin": "^7.22.10",


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When generating css, react-dev-utils generates hash.
However, when creating a hash, `+` is not excluded.
Other developers also had the same problem, so they requested a react-dev-utils PR as shown below, but it has not been merged for over a year, so it is difficult to expect anything.
https://github.com/facebook/create-react-app/pull/12013

For internal development purposes, a hashless getLocalIdent called `getSimpleCSSModuleLocalIdent` has been implemented in @enact/dev-utils in the past.
This issue can be resolved by stopping using React-dev-utils and adding an option to create hashes without the '+' in @enact/dev-utils. (this code is from https://github.com/facebook/create-react-app/pull/12013)

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Remove getCSSModuleLocalIdent and use cssModuleIdent only

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-200

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)