### PR TITLE
WRQ-7861 : Added an argument to the range utility function to include the storybook-provided if option

### DIFF
--- a/addons/controls/range.js
+++ b/addons/controls/range.js
@@ -46,11 +46,9 @@ const range = (name, storyObj, config, opts, preferredValue, otherOpts) => {
 	}
 
 	// If there is no `otherOpts` object
-	if(!otherOpts) {
+	if (!otherOpts) {
 		otherOpts = {};
 	}
-
-	console.log('otherOpts after ',otherOpts);
 	storyObj.args[name] = preferredValue != null ? preferredValue : config.defaultProps[name];
 	storyObj.argTypes[name] = {
 		control: {

--- a/addons/controls/range.js
+++ b/addons/controls/range.js
@@ -10,9 +10,10 @@
  * * config - config object with at least a `defaultProps` key containing a map of props and their default values
  * * opts - range-specific control options (opts from the standard Controls docs)
  * * preferredValue - (optional) a sample-specific initially selected value
+ * * otherOpts - (optional) other options object unrelated to the control options
  */
 
-const range = (name, storyObj, config, opts, preferredValue) => {
+const range = (name, storyObj, config, opts, preferredValue, otherOpts) => {
 	if (typeof opts === 'number') {
 		// opts was omitted, causing the preferredValue to be the last value. Reassignment dipsy-doodle.
 		preferredValue = opts;
@@ -44,6 +45,12 @@ const range = (name, storyObj, config, opts, preferredValue) => {
 		config.defaultProps = {};
 	}
 
+	// If there is no `otherOpts` object
+	if(!otherOpts) {
+		otherOpts = {};
+	}
+
+	console.log('otherOpts after ',otherOpts);
 	storyObj.args[name] = preferredValue != null ? preferredValue : config.defaultProps[name];
 	storyObj.argTypes[name] = {
 		control: {
@@ -52,7 +59,8 @@ const range = (name, storyObj, config, opts, preferredValue) => {
 		},
 		table: {
 			category: config.groupId
-		}
+		},
+		...otherOpts
 	};
 };
 

--- a/addons/controls/range.js
+++ b/addons/controls/range.js
@@ -10,7 +10,7 @@
  * * config - config object with at least a `defaultProps` key containing a map of props and their default values
  * * opts - range-specific control options (opts from the standard Controls docs)
  * * preferredValue - (optional) a sample-specific initially selected value
- * * otherOpts - (optional) other options object unrelated to the control options
+ * * otherOpts - (optional) options specifying argTypes excluding the `control` and `table` keys
  */
 
 const range = (name, storyObj, config, opts, preferredValue, otherOpts) => {
@@ -49,6 +49,7 @@ const range = (name, storyObj, config, opts, preferredValue, otherOpts) => {
 	if (!otherOpts) {
 		otherOpts = {};
 	}
+
 	storyObj.args[name] = preferredValue != null ? preferredValue : config.defaultProps[name];
 	storyObj.argTypes[name] = {
 		control: {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Unrelated properties should not be visible in the sampler to avoid confusing users.
So, Allows you to enable or disable some properties when the value of a particular property changes.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added otherOpts argument to the range utility function to include the storybook-provided if option.
Storybook supports 'disable controls for specific properties' as a if option.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
TODO : another utility function (select.js, object.js, etc.) should be update to receive if option as argument.

### Links
[//]: # (Related issues, references)
WRQ-7861

### Comments
Enact-DCO-1.0-Signed-off-by: Hyelyn Kim (myelyn.kim@lge.com)