### PR TITLE
WRQ-19328: Fix React 18.3 warnings in storybook-utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## unreleased
+
+* Fixed `mergeComponentMetadata` function to get defaultProps and defaultPropValues of components.
+
 ## 5.1.3 (February 21, 2024)
 
 * Removed `getCSSModuleLocalIdent` to fix unexpected behaviors in css-loader.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## unreleased
 
-* Fixed `mergeComponentMetadata` function to get defaultProps and defaultPropValues of components.
+* Fixed `mergeComponentMetadata` to take default prop values from `defaultPropValues` as well as `defaultProps` since `defaultProps` in function component has been deprecated.
 
 ## 5.1.3 (February 21, 2024)
 

--- a/addons/controls/boolean.js
+++ b/addons/controls/boolean.js
@@ -30,8 +30,9 @@ const boolean = (name, storyObj, config, preferredValue) => {
 	}
 
 	// If there is no `defaultProps` object on the config object
-	if (!config.defaultProps) {
-		config.defaultProps = {};
+	let defaultProps = config.defaultProps;
+	if (!defaultProps) {
+		defaultProps = {};
 	}
 
 	// If there's no group ID but there is a display name, use that for the group ID
@@ -40,7 +41,7 @@ const boolean = (name, storyObj, config, preferredValue) => {
 	}
 
 	// Set false for default boolean props that are not defined.
-	const defaultValue = config.defaultProps[name] != null ? config.defaultProps[name] : false;
+	const defaultValue = defaultProps[name] != null ? defaultProps[name] : false;
 
 	storyObj.args[name] = preferredValue != null ? preferredValue : defaultValue;
 	storyObj.argTypes[name] = {

--- a/addons/controls/color.js
+++ b/addons/controls/color.js
@@ -34,11 +34,12 @@ const color = (name, storyObj, config, preferredValue) => {
 	}
 
 	// If there is no `defaultProps` object on the config object
-	if (!config.defaultProps) {
-		config.defaultProps = {};
+	let defaultProps = config.defaultProps;
+	if (!defaultProps) {
+		defaultProps = {};
 	}
 
-	storyObj.args[name] = preferredValue != null ? preferredValue : config.defaultProps[name];
+	storyObj.args[name] = preferredValue != null ? preferredValue : defaultProps[name];
 	storyObj.argTypes[name] = {
 		control: {
 			type: 'color'

--- a/addons/controls/number.js
+++ b/addons/controls/number.js
@@ -34,11 +34,12 @@ const number = (name, storyObj, config, preferredValue) => {
 	}
 
 	// If there is no `defaultProps` object on the config object
-	if (!config.defaultProps) {
-		config.defaultProps = {};
+	let defaultProps = config.defaultProps;
+	if (!defaultProps) {
+		defaultProps = {};
 	}
 
-	storyObj.args[name] = preferredValue != null ? preferredValue : config.defaultProps[name];
+	storyObj.args[name] = preferredValue != null ? preferredValue : defaultProps[name];
 	storyObj.argTypes[name] = {
 		control: {
 			type: 'number'

--- a/addons/controls/object.js
+++ b/addons/controls/object.js
@@ -38,11 +38,12 @@ const object = (name, storyObj, config, preferredObject) => {
 	}
 
 	// If there is no `defaultProps` object on the config object
-	if (!config.defaultProps) {
-		config.defaultProps = {};
+	let defaultProps = config.defaultProps;
+	if (!defaultProps) {
+		defaultProps = {};
 	}
 
-	storyObj.args[name] = nullify(preferredObject || config.defaultProps[name]);
+	storyObj.args[name] = nullify(preferredObject || defaultProps[name]);
 	storyObj.argTypes[name] = {
 		control: {
 			type: 'object'

--- a/addons/controls/range.js
+++ b/addons/controls/range.js
@@ -41,8 +41,9 @@ const range = (name, storyObj, config, opts, preferredValue, otherOpts) => {
 	}
 
 	// If there is no `defaultProps` object on the config object
-	if (!config.defaultProps) {
-		config.defaultProps = {};
+	let defaultProps = config.defaultProps;
+	if (!defaultProps) {
+		defaultProps = {};
 	}
 
 	// If there is no `otherOpts` object
@@ -50,7 +51,7 @@ const range = (name, storyObj, config, opts, preferredValue, otherOpts) => {
 		otherOpts = {};
 	}
 
-	storyObj.args[name] = preferredValue != null ? preferredValue : config.defaultProps[name];
+	storyObj.args[name] = preferredValue != null ? preferredValue : defaultProps[name];
 	storyObj.argTypes[name] = {
 		control: {
 			type: 'range',

--- a/addons/controls/select.js
+++ b/addons/controls/select.js
@@ -41,12 +41,13 @@ const select = (name, storyObj, items, config, selectedValue) => {
 	}
 
 	// If there is no `defaultProps` object on the config object
-	if (!config.defaultProps) {
-		config.defaultProps = {};
+	let defaultProps = config.defaultProps;
+	if (!defaultProps) {
+		defaultProps = {};
 	}
 
 	const defaultAppender = (key, label = key) => {
-		return (key || '') + (config.defaultProps[name] === label && key ? defaultString : '');
+		return (key || '') + (defaultProps[name] === label && key ? defaultString : '');
 	};
 
 	const replaceNullString = key => {
@@ -65,7 +66,7 @@ const select = (name, storyObj, items, config, selectedValue) => {
 		}
 	}
 
-	const value = nullify(selectedValue != null ? selectedValue : config.defaultProps[name]);
+	const value = nullify(selectedValue != null ? selectedValue : defaultProps[name]);
 	storyObj.args[name] = Object.keys(labels).find(key => labels[key] === value);
 
 	storyObj.argTypes[name] = {

--- a/addons/controls/text.js
+++ b/addons/controls/text.js
@@ -38,11 +38,12 @@ const text = (name, storyObj, config, preferredValue) => {
 	}
 
 	// If there is no `defaultProps` object on the Config object
-	if (!config.defaultProps) {
-		config.defaultProps = {};
+	let defaultProps = config.defaultProps;
+	if (!defaultProps) {
+		defaultProps = {};
 	}
 
-	storyObj.args[name] = nullify(preferredValue != null ? preferredValue : config.defaultProps[name]);
+	storyObj.args[name] = nullify(preferredValue != null ? preferredValue : defaultProps[name]);
 	storyObj.argTypes[name] = {
 		control: {
 			type: 'text'

--- a/propTables.js
+++ b/propTables.js
@@ -7,7 +7,7 @@ const mergeComponentMetadata = (displayName, ...components) => {
 	fn.displayName = displayName;
 	fn.groupId = displayName;
 	fn.propTypes = merge(components, 'propTypes');
-	fn.defaultProps = merge(components, 'defaultProps');
+	fn.defaultProps = Object.assign({}, merge(components, 'defaultProps'), merge(components, 'defaultPropValues'));
 
 	return fn;
 };


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In storybook-utils, we take `defaultProps` from components to determine the default prop values for sampler.
But `defaultProps` in function components will be removed in React 19.
So we need an alternative.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fix React 18.3 warnings in storybook-utils related to the defualtProps by introducing `defaultPropValues` as an alternative for determining default prop.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
This fix is a temporal approach since we couldn't find a root cause due to shortage of time.
When the envirionment is set, we need to look into it deeply.
Note that this change is backward compatible so the target branch is `develop`.

### Links
[//]: # (Related issues, references)
WRQ-19328

### Comments
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

