### PR TITLE
WRQ-19494: Update `css-loader` version to `7.x`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## unreleased
 
-* Updated `css-loader` to `^7.1.2` and changed `css-loader` options to restore 6.x behavior.
+* Updated `css-loader` to 7.x and changed `css-loader` options to restore 6.x behavior.
 
 ## 6.0.0-rc.1 (July 9, 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## unreleased
 
+* Updated `css-loader` to `^7.1.2` and changed `css-loader` options to restore 6.x behavior.
 * Migrated to storybook 8.
-* Updated the minimum version of Node to `18.0.0`.
+* Updated the minimum version of Node to `^18.12.0`.
 * Removed custom docs addon and `@storybook/addon-docs` dependency because storybook 7 doesn't allow customization of `@storybook/addon-docs`.
 
 ## 5.1.4 (May 22, 2024)

--- a/configs/webpack.js
+++ b/configs/webpack.js
@@ -29,8 +29,7 @@ module.exports = function (config, mode, dirname) {
 						// Options to restore 6.x behavior:
 						// https://github.com/webpack-contrib/css-loader/blob/master/CHANGELOG.md#700-2024-04-04
 						modules: {
-							namedExport: false,
-							exportLocalsConvention: 'as-is'
+							namedExport: false
 						}
 					},
 					cssLoaderOptions

--- a/configs/webpack.js
+++ b/configs/webpack.js
@@ -23,7 +23,16 @@ module.exports = function (config, mode, dirname) {
 			{
 				loader: require.resolve('css-loader'),
 				options: Object.assign(
-					{importLoaders: preProcessor ? 2 : 1, sourceMap: shouldUseSourceMap},
+					{
+						importLoaders: preProcessor ? 2 : 1,
+						sourceMap: shouldUseSourceMap,
+						// Options to restore 6.x behavior:
+						// https://github.com/webpack-contrib/css-loader/blob/master/CHANGELOG.md#700-2024-04-04
+						modules: {
+							namedExport: false,
+							exportLocalsConvention: 'as-is'
+						}
+					},
 					cssLoaderOptions
 				)
 			},

--- a/configs/webpack.js
+++ b/configs/webpack.js
@@ -25,15 +25,17 @@ module.exports = function (config, mode, dirname) {
 				options: Object.assign(
 					{
 						importLoaders: preProcessor ? 2 : 1,
-						sourceMap: shouldUseSourceMap,
-						// Options to restore 6.x behavior:
-						// https://github.com/webpack-contrib/css-loader/blob/master/CHANGELOG.md#700-2024-04-04
+						sourceMap: shouldUseSourceMap
+					},
+					cssLoaderOptions,
+					// Options to restore 6.x behavior:
+					// https://github.com/webpack-contrib/css-loader/blob/master/CHANGELOG.md#700-2024-04-04
+					{
 						modules: {
 							namedExport: false,
 							exportLocalsConvention: 'as-is'
 						}
-					},
-					cssLoaderOptions
+					}
 				)
 			},
 			{

--- a/configs/webpack.js
+++ b/configs/webpack.js
@@ -29,7 +29,8 @@ module.exports = function (config, mode, dirname) {
 						// Options to restore 6.x behavior:
 						// https://github.com/webpack-contrib/css-loader/blob/master/CHANGELOG.md#700-2024-04-04
 						modules: {
-							namedExport: false
+							namedExport: false,
+							exportLocalsConvention: 'as-is'
 						}
 					},
 					cssLoaderOptions

--- a/configs/webpack.js
+++ b/configs/webpack.js
@@ -27,15 +27,7 @@ module.exports = function (config, mode, dirname) {
 						importLoaders: preProcessor ? 2 : 1,
 						sourceMap: shouldUseSourceMap
 					},
-					cssLoaderOptions,
-					// Options to restore 6.x behavior:
-					// https://github.com/webpack-contrib/css-loader/blob/master/CHANGELOG.md#700-2024-04-04
-					{
-						modules: {
-							namedExport: false,
-							exportLocalsConvention: 'as-is'
-						}
-					}
+					cssLoaderOptions
 				)
 			},
 			{
@@ -114,7 +106,13 @@ module.exports = function (config, mode, dirname) {
 			test: /\.module\.css$/,
 			use: getStyleLoaders({
 				modules: {
-					getLocalIdent
+					getLocalIdent,
+					// Options to restore 6.x behavior:
+					// https://github.com/webpack-contrib/css-loader/blob/master/CHANGELOG.md#700-2024-04-04
+					modules: {
+						namedExport: false,
+						exportLocalsConvention: 'as-is'
+					}
 				}
 			})
 		},
@@ -124,7 +122,13 @@ module.exports = function (config, mode, dirname) {
 			// modular CSS support.
 			use: getStyleLoaders({
 				modules: {
-					...(app.forceCSSModules ? {getLocalIdent} : {mode: 'icss'})
+					...(app.forceCSSModules ? {getLocalIdent} : {mode: 'icss'}),
+					// Options to restore 6.x behavior:
+					// https://github.com/webpack-contrib/css-loader/blob/master/CHANGELOG.md#700-2024-04-04
+					modules: {
+						namedExport: false,
+						exportLocalsConvention: 'as-is'
+					}
 				}
 			}),
 			// Don't consider CSS imports dead code even if the
@@ -137,7 +141,13 @@ module.exports = function (config, mode, dirname) {
 			test: /\.module\.less$/,
 			use: getLessStyleLoaders({
 				modules: {
-					getLocalIdent
+					getLocalIdent,
+					// Options to restore 6.x behavior:
+					// https://github.com/webpack-contrib/css-loader/blob/master/CHANGELOG.md#700-2024-04-04
+					modules: {
+						namedExport: false,
+						exportLocalsConvention: 'as-is'
+					}
 				}
 			})
 		},
@@ -145,7 +155,13 @@ module.exports = function (config, mode, dirname) {
 			test: /\.less$/,
 			use: getLessStyleLoaders({
 				modules: {
-					...(app.forceCSSModules ? {getLocalIdent} : {mode: 'icss'})
+					...(app.forceCSSModules ? {getLocalIdent} : {mode: 'icss'}),
+					// Options to restore 6.x behavior:
+					// https://github.com/webpack-contrib/css-loader/blob/master/CHANGELOG.md#700-2024-04-04
+					modules: {
+						namedExport: false,
+						exportLocalsConvention: 'as-is'
+					}
 				}
 			}),
 			sideEffects: true

--- a/configs/webpack.js
+++ b/configs/webpack.js
@@ -18,13 +18,23 @@ module.exports = function (config, mode, dirname) {
 	app.setEnactTargetsAsDefault();
 
 	const getStyleLoaders = (cssLoaderOptions = {}, preProcessor) => {
+		const mergedCssLoaderOptions = {
+			...cssLoaderOptions,
+			modules: {
+				...cssLoaderOptions.modules,
+				// Options to restore 6.x behavior:
+				// https://github.com/webpack-contrib/css-loader/blob/master/CHANGELOG.md#700-2024-04-04
+				namedExport: false,
+				exportLocalsConvention: 'as-is'
+			}
+		};
 		const loaders = [
 			process.env.INLINE_STYLES ? require.resolve('style-loader') : MiniCssExtractPlugin.loader,
 			{
 				loader: require.resolve('css-loader'),
 				options: Object.assign(
 					{importLoaders: preProcessor ? 2 : 1, sourceMap: shouldUseSourceMap},
-					cssLoaderOptions
+					mergedCssLoaderOptions
 				)
 			},
 			{
@@ -103,13 +113,7 @@ module.exports = function (config, mode, dirname) {
 			test: /\.module\.css$/,
 			use: getStyleLoaders({
 				modules: {
-					getLocalIdent,
-					// Options to restore 6.x behavior:
-					// https://github.com/webpack-contrib/css-loader/blob/master/CHANGELOG.md#700-2024-04-04
-					modules: {
-						namedExport: false,
-						exportLocalsConvention: 'as-is'
-					}
+					getLocalIdent
 				}
 			})
 		},
@@ -119,13 +123,7 @@ module.exports = function (config, mode, dirname) {
 			// modular CSS support.
 			use: getStyleLoaders({
 				modules: {
-					...(app.forceCSSModules ? {getLocalIdent} : {mode: 'icss'}),
-					// Options to restore 6.x behavior:
-					// https://github.com/webpack-contrib/css-loader/blob/master/CHANGELOG.md#700-2024-04-04
-					modules: {
-						namedExport: false,
-						exportLocalsConvention: 'as-is'
-					}
+					...(app.forceCSSModules ? {getLocalIdent} : {mode: 'icss'})
 				}
 			}),
 			// Don't consider CSS imports dead code even if the
@@ -138,13 +136,7 @@ module.exports = function (config, mode, dirname) {
 			test: /\.module\.less$/,
 			use: getLessStyleLoaders({
 				modules: {
-					getLocalIdent,
-					// Options to restore 6.x behavior:
-					// https://github.com/webpack-contrib/css-loader/blob/master/CHANGELOG.md#700-2024-04-04
-					modules: {
-						namedExport: false,
-						exportLocalsConvention: 'as-is'
-					}
+					getLocalIdent
 				}
 			})
 		},
@@ -152,13 +144,7 @@ module.exports = function (config, mode, dirname) {
 			test: /\.less$/,
 			use: getLessStyleLoaders({
 				modules: {
-					...(app.forceCSSModules ? {getLocalIdent} : {mode: 'icss'}),
-					// Options to restore 6.x behavior:
-					// https://github.com/webpack-contrib/css-loader/blob/master/CHANGELOG.md#700-2024-04-04
-					modules: {
-						namedExport: false,
-						exportLocalsConvention: 'as-is'
-					}
+					...(app.forceCSSModules ? {getLocalIdent} : {mode: 'icss'})
 				}
 			}),
 			sideEffects: true

--- a/configs/webpack.js
+++ b/configs/webpack.js
@@ -23,10 +23,7 @@ module.exports = function (config, mode, dirname) {
 			{
 				loader: require.resolve('css-loader'),
 				options: Object.assign(
-					{
-						importLoaders: preProcessor ? 2 : 1,
-						sourceMap: shouldUseSourceMap
-					},
+					{importLoaders: preProcessor ? 2 : 1, sourceMap: shouldUseSourceMap},
 					cssLoaderOptions
 				)
 			},

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@storybook/addon-docs": "^6.5.16",
     "@storybook/addon-toolbars": "^6.5.16",
     "babel-preset-enact": "^0.1.7",
-    "css-loader": "^6.11.0",
+    "css-loader": "^7.1.2",
     "less": "^4.2.0",
     "less-loader": "^12.2.0",
     "mini-css-extract-plugin": "^2.8.1",


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When checking for module vulnerabilities and updates, I found that major version v7 of css-loader was recently released.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Updated `css-loader` to 7.x 
- Changed `css-loader` options to restore 6.x behavior.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
- Add css-loader config for applying 6.x behavior(to prevent app/framework migration)
https://github.com/webpack-contrib/css-loader/blob/master/CHANGELOG.md#700-2024-04-04
```
module.exports = {
  module: {
    rules: [
      {
        test: /\.css$/i,
        loader: "css-loader",
        options: {
          modules: {
            namedExport: false,
            exportLocalsConvention: 'as-is'
          },
        },
      },
    ],
  },
};
```
- `mergedCssLoaderOptions` was added to inherit `cssLoaderOptions`.
This will be used in `getStyleLoaders` function that used into each css/less/sass extensions

### Links
[//]: # (Related issues, references)
WRQ-19494

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)