### PR TITLE
WRQ-28555: Fixed action item cannot be logged more than 10 in `actions` panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## unreleased
+
+* Removed limit for the number of items logged into the actions panel
+
 ## 6.0.0-rc.2 (July 22, 2024)
 
 * Updated `css-loader` to 7.x and changed `css-loader` options to restore 6.x behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## unreleased
 
-* Removed limit for the number of items logged into the actions panel
+* Removed limit for the number of items logged into the actions panel.
 
 ## 6.0.0-rc.2 (July 22, 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## unreleased
 
-* Removed limit for the number of items logged into the actions panel.
+* Changed the limit for the number of items logged into the actions panel to 200.
 
 ## 6.0.0-rc.2 (July 22, 2024)
 

--- a/addons/actions/configure.js
+++ b/addons/actions/configure.js
@@ -2,6 +2,9 @@ import {configureActions as addonConfigureActions} from '@storybook/addon-action
 
 const configureActions = opts => {
 	return addonConfigureActions({
+		// TODO: Set to limit of 200 is a workaround. We need to update event display to sort in latest order.
+		// Limit the number of items logged into the actions panel
+		limit: 200,
 		...opts
 	});
 };

--- a/addons/actions/configure.js
+++ b/addons/actions/configure.js
@@ -2,8 +2,6 @@ import {configureActions as addonConfigureActions} from '@storybook/addon-action
 
 const configureActions = opts => {
 	return addonConfigureActions({
-		// Limit the number of items logged into the actions panel
-		limit: 10,
 		...opts
 	});
 };

--- a/addons/actions/configure.js
+++ b/addons/actions/configure.js
@@ -2,7 +2,8 @@ import {configureActions as addonConfigureActions} from '@storybook/addon-action
 
 const configureActions = opts => {
 	return addonConfigureActions({
-		// TODO: Set to limit of 200 is a workaround. We need to update event display to sort in latest order.
+		// TODO: Set the limit of 200 as a workaround.
+		// We hope storybook to fix the action log to be sorted as the latest on the top.
 		// Limit the number of items logged into the actions panel
 		limit: 200,
 		...opts


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
On storybook 8 , the most recent action is placed on the bottom of the log list in the action panel. When a limit is set, only the oldest 10 actions can be seen by the user

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Set the limit for the number of items logged into the actions panel to 200, in order to see the latest logs

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-28555

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian ([daniel.stoian@lgepartner.com](mailto:daniel.stoian@lgepartner.com))
