### PR TITLE
WRR-8543: Changed CSS classnames to be hashed when production build

### DIFF
--- a/configs/webpack.js
+++ b/configs/webpack.js
@@ -98,7 +98,7 @@ module.exports = function (config, mode, dirname) {
 			test: /\.module\.css$/,
 			use: getStyleLoaders({
 				modules: {
-					getLocalIdent
+					...(isProduction ? {} : {getLocalIdent})
 				}
 			})
 		},
@@ -108,7 +108,8 @@ module.exports = function (config, mode, dirname) {
 			// modular CSS support.
 			use: getStyleLoaders({
 				modules: {
-					...(app.forceCSSModules ? {getLocalIdent} : {mode: 'icss'})
+					...(app.forceCSSModules ? {} : {mode: 'icss'}),
+					...(!app.forceCSSModules && isProduction ? {} : {getLocalIdent})
 				}
 			}),
 			// Don't consider CSS imports dead code even if the
@@ -121,7 +122,7 @@ module.exports = function (config, mode, dirname) {
 			test: /\.module\.less$/,
 			use: getLessStyleLoaders({
 				modules: {
-					getLocalIdent
+					...(isProduction ? {} : {getLocalIdent})
 				}
 			})
 		},
@@ -129,7 +130,8 @@ module.exports = function (config, mode, dirname) {
 			test: /\.less$/,
 			use: getLessStyleLoaders({
 				modules: {
-					...(app.forceCSSModules ? {getLocalIdent} : {mode: 'icss'})
+					...(app.forceCSSModules ? {} : {mode: 'icss'}),
+					...(!app.forceCSSModules && isProduction ? {} : {getLocalIdent})
 				}
 			}),
 			sideEffects: true


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
To reduce the size of built Enact app's CSS, changed CSS classnames to be hashed when production build

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Changed the webpack config to use [hash:base64] of css-loader's `localIdentName` property when production build

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
When we build the storybook with `npm run pack`, it seems there is no way to build it with `development` mode in storybook 6.5. I think there will be no issue but if anybody thinks different, we need to reconsider merging this.

### Links
[//]: # (Related issues, references)
WRR-8543

### Comments
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)