### PR TITLE
NXT-13025: Added PseudoStateFocusBridge util function

### DIFF
--- a/decorators/PseudoStateFocusBridge.js
+++ b/decorators/PseudoStateFocusBridge.js
@@ -1,0 +1,95 @@
+/* global FocusEvent, MutationObserver, cancelAnimationFrame, requestAnimationFrame */
+
+import {useEffect} from 'react';
+
+/**
+ * Creates a Storybook decorator that bridges
+ * [storybook-addon-pseudo-states](https://www.npmjs.com/package/storybook-addon-pseudo-states) to Enact's
+ * focus model.
+ *
+ * The addon only toggles CSS pseudo-classes; it cannot drive Enact's focus visuals, which are gated by
+ * Spotlight input-mode (`.spotlight-input-*` on `#storybook-root`) and, for components like
+ * `TooltipDecorator`, by React state that only real focus/hover events set. The decorator observes the
+ * forcing class the addon applies to `<body>` (`pseudo-focus-all` / `pseudo-hover-all` ) and mirrors it
+ * with genuine Enact focus on the story's own spottable element:
+ *
+ *   - `.focus()` sets `document.activeElement`, so CSS `:focus` styling applies, and `spotlight-input-key`
+ *     is added so Enact's input-mode-gated focus rules are eligible.
+ *   - a bubbling `focusin` is dispatched so React's delegated `onFocus` runs even when the preview iframe
+ *     does not hold system focus (as when the pseudo-state is toggled from the addon toolbar), which is
+ *     what makes state-driven UI such as tooltips appear and stay shown.
+ *
+ * @param   {Object}   [config]                  Configuration options.
+ * @param   {String}   [config.ignoreSelector='[class*="_Header_"]']  CSS selector matching the sampler's
+ *   chrome (e.g. a Panel `Header`, or Agate's `Panels controls`) whose spottable elements should be
+ *   skipped, so the story's own control is focused instead. Themes differ here, which is why it is
+ *   configurable. Pass a falsy value to disable chrome-skipping entirely.
+ *
+ * @returns {Function}                            A Storybook decorator.
+ * @memberof storybook-utils/decorators
+ * @public
+ */
+const createPseudoStateFocusBridge = ({ignoreSelector = '[class*="_Header_"]'} = {}) => {
+	const PseudoStateFocusBridge = (story) => {
+		useEffect(() => {
+			const root = document.getElementById('storybook-root');
+			if (!root) return;
+
+			const isForced = () => /pseudo-(focus|hover|active)/.test(document.body.className);
+			// Skip the sampler chrome and target the story's own control.
+			const findSpottable = () => [...root.querySelectorAll('.spottable')].find((el) => (ignoreSelector ? !el.closest(ignoreSelector) : true));
+
+			let rafId = null;
+			let target = null;
+			let wasForced = false;
+
+			const forceFocus = (tries = 0) => {
+				const spottable = findSpottable();
+				if (spottable) {
+					target = spottable;
+					root.classList.add('spotlight-input-key');
+					spottable.focus();
+					spottable.dispatchEvent(new FocusEvent('focusin', {bubbles: true}));
+				} else if (tries < 10) {
+					rafId = requestAnimationFrame(() => forceFocus(tries + 1));
+				}
+			};
+
+			const clearFocus = () => {
+				const el = target || findSpottable();
+				if (el) {
+					el.blur();
+					el.dispatchEvent(new FocusEvent('focusout', {bubbles: true}));
+				}
+				target = null;
+			};
+
+			const sync = () => {
+				if (rafId) cancelAnimationFrame(rafId);
+				const forced = isForced();
+				if (forced) {
+					forceFocus();
+				} else if (wasForced) {
+					clearFocus();
+				}
+				wasForced = forced;
+			};
+
+			const observer = new MutationObserver(sync);
+			observer.observe(document.body, {attributes: true, attributeFilter: ['class']});
+			sync();
+
+			return () => {
+				observer.disconnect();
+				if (rafId) cancelAnimationFrame(rafId);
+			};
+		}, []);
+
+		return story();
+	};
+
+	return PseudoStateFocusBridge;
+};
+
+export default createPseudoStateFocusBridge;
+export {createPseudoStateFocusBridge};

--- a/decorators/index.js
+++ b/decorators/index.js
@@ -1,0 +1,5 @@
+/*
+ * Re-Export all the relevant named exports from all within this folder.
+ */
+
+export * from './PseudoStateFocusBridge';

--- a/index.js
+++ b/index.js
@@ -8,3 +8,4 @@ export * from './propTables';
 export * from './nullify';
 export * from './emptify';
 export * as addons from './addons';
+export * as decorators from './decorators';


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](https://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](https://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added a PseudoStateFocusBridge decorator. The addon only flips CSS classes, but Enact focus visuals are gated by Spotlight input-mode and, for components like TooltipDecorator, by React state. The bridge observes the addon's forced state and mirrors it with real Enact focus (.focus() + a dispatched focusin + spotlight-input-key), so focus styling and state-driven UI (e.g. tooltips) actually respond.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
NXT-13025

### Comments
Enact-DCO-1.0-Signed-off-by: Daniel Stoian ([daniel.stoian@lgepartner.com](mailto:daniel.stoian@lgepartner.com))